### PR TITLE
Less encodes

### DIFF
--- a/add_audio_track_mt.py
+++ b/add_audio_track_mt.py
@@ -15,7 +15,7 @@ import json
 # Empty list selects all seasons (specify as string)
 seasons = ["01"]
 # Empty list selects all episodes (specify as string)
-episodes = ["03"]
+episodes = ["01"]
 
 # Input path containing different season folders and info.xml
 inputPath = "E:/Filme/JDownloader/Stargate Atlantis/"
@@ -27,17 +27,13 @@ outputPath = "E:/Filme/JDownloader/Audio-Video-Scripts/Test/"
 titleLanguage = "DE"
 
 # Normalize audio
-enableNormalization = False
+enableNormalization = True
 loudnessTarget = -23.0		# EBU recommendation: (-23.0)
 loudnessTruePeak = -1.0		# EBU limit (-1.0)
 loudnessRange = 18.0		# https://www.audiokinetic.com/library/edge/?source=Help&id=more_on_loudness_range_lra (18.0)
 
-# Set file metadata using MKVPropedit
-# TODO: remove mkvpropedit
-enableMKVPropedit = False
-
 # Enable logging to file
-enableLogFile = False
+enableLogFile = True
 enableUniqueLogFile = False
 
 # Maximum number of simultaneous threads
@@ -55,13 +51,12 @@ ffmpegNormalize = "ffmpeg-normalize"		# Needs to be installed with pip3 install 
 mkvpropedit = "mkvpropedit.exe"
 
 # RegEx strings
-REGEX_MEDIA_STREAM = r"Stream #(\d+):(\d+):\s*Video:"
-REGEX_TOTAL_FRAMES = r"NUMBER_OF_FRAMES\s*:\s*(\d+)"
-REGEX_CURRENT_FRAME = r"frame\s*=\s*(\d+)"
-REGEX_LOUDNORM = r"\[Parsed_loudnorm_(\d+)"
-
-REGEX_NORMALIZATION = r"Stream\s*(\d+)/(\d+):\s*(\d+)%"
-REGEX_NORMALIZATION_SECOND = r"Second Pass\s*:\s*(\d+)%"
+REGEX_MEDIA_STREAM		= r"Stream #(\d+):(\d+):\s*Video:"
+REGEX_TOTAL_FRAMES		= r"NUMBER_OF_FRAMES\s*:\s*(\d+)"
+REGEX_TOTAL_DURATION	= r"DURATION\s*:\s*(\d+):(\d+):(\d+.\d+)"
+REGEX_CURRENT_FRAME		= r"frame\s*=\s*(\d+)"
+REGEX_CURRENT_TIME		= r"time=(\d+):(\d+):(\d+).(\d+)"
+REGEX_LOUDNORM			= r"\[Parsed_loudnorm_(\d+)"
 
 REGEX_MKVPROPEDIT = r"Progress:\s*(\d+)%"
 
@@ -152,6 +147,85 @@ def getAudioCodecProfile(codecProfile):
 		errorCritical("Unknown audio codec profile: " + codecProfile)
 
 
+def decodeFfmpegOutput(process, progressBar, maxProgress):
+	captureTotalFrames = False
+	jsonStart = False
+	totalFrames = 0
+	totalDurationS = 0
+	percentCounter = 0
+	regexPatternMediaStream		= re.compile(REGEX_MEDIA_STREAM)
+	regexPatternTotalFrames		= re.compile(REGEX_TOTAL_FRAMES)
+	regexPatternTotalDuration	= re.compile(REGEX_TOTAL_DURATION)
+	regexPatternCurrentFrame	= re.compile(REGEX_CURRENT_FRAME)
+	regexPatternCurrentTime		= re.compile(REGEX_CURRENT_TIME)
+
+	# Normalization output
+	regexPatternLoudNorm = re.compile(REGEX_LOUDNORM)
+	jsonStrings = []
+
+	# Decode output from ffmpeg
+	for line in process.stdout:
+		# Update progress bar
+		regexMatchFrame = regexPatternCurrentFrame.match(line.strip())
+		regexMatchTime = regexPatternCurrentTime.search(line.strip())
+		if regexMatchFrame:
+			progress = int(((int(regexMatchFrame.group(1)) * maxProgress) / totalFrames) * (progressAudioEncode / 100))
+			progressBar.update(progress - percentCounter)
+			percentCounter = progress
+			continue
+		elif regexMatchTime:
+			timeS  = int(regexMatchTime.group(1)) * 3600		# Hours
+			timeS += int(regexMatchTime.group(2)) * 60			# Minutes
+			timeS += float(regexMatchTime.group(3))				# Seconds
+			progress = int(((timeS * maxProgress) / totalDurationS) * (progressAudioEncode / 100))
+			progressBar.update(progress - percentCounter)
+			percentCounter = progress
+			continue
+
+		# Check for video stream
+		regexMatch = regexPatternMediaStream.match(line.strip())
+		if regexMatch:
+			if regexMatch.group(1) == "0" and regexMatch.group(2) == "0":
+				captureTotalFrames = True
+				continue
+
+		# Get total frames of video stream
+		if captureTotalFrames:
+			regexMatch = regexPatternTotalFrames.match(line.strip())
+			if regexMatch:
+				totalFrames = int(regexMatch.group(1))
+				captureTotalFrames = False
+				continue
+
+		# Get maximum total duration
+		regexMatch = regexPatternTotalDuration.match(line.strip())
+		if regexMatch:
+			durationS  = int(regexMatch.group(1)) * 3600		# Hours
+			durationS += int(regexMatch.group(2)) * 60			# Minutes
+			durationS += float(regexMatch.group(3))				# Seconds
+			if durationS > totalDurationS:
+				totalDurationS = durationS
+			continue
+
+		# Get normalization output
+		if enableNormalization:
+			regexMatch = regexPatternLoudNorm.match(line.strip())
+			if regexMatch:
+				jsonStrings.append("")
+				jsonStart = True
+				continue
+			elif jsonStart:
+				jsonStrings[-1] += line
+				continue
+
+	# Add any missing percent value to progress bar
+	progressBar.update(maxProgress - percentCounter)
+	progressBar.refresh()
+
+	# Return json output
+	return [json.loads(s) for s in jsonStrings]
+
+
 def processEpisode(ep):
 	global threadProgress
 
@@ -162,7 +236,6 @@ def processEpisode(ep):
 					   + ep.filePrefix \
 					   + ep.titleDE if titleLanguage == "DE" else ep.titleEN
 	convertedVideoFilePath = outputPath + seasonPath + episodeFullTitle + ".mkv"
-	tempFilePath = outputPath + ep.seasonPath + "temp_" + episodeFullTitle + ".mkv"
 
 	audioSpeed = 1.0
 	audioCodecs = []
@@ -267,12 +340,13 @@ def processEpisode(ep):
 			)
 
 			# Add thread progress to dictionary
+			maxProgress = amountAudioStreams[1] * progressAudioEncode + progressMKVProperties
+			if enableNormalization:
+				maxProgress = (amountAudioStreams[0] + amountAudioStreams[1]) * 2 * progressAudioEncode + progressMKVProperties
 			threadProgress[threading.get_ident()] = tqdm(
-				total = (amountAudioStreams[0] * (2 if enableNormalization else 0)
-						 + amountAudioStreams[1] * (3 if enableNormalization else 1))
-						* progressAudioEncode + progressMKVProperties,
+				total = maxProgress,
 				desc = "Processing \"" + ep.seasonPath + ep.fileVideo + "\"",
-				leave = False
+				leave = False,
 			)
 
 			if enableNormalization:
@@ -342,31 +416,12 @@ def processEpisode(ep):
 						encoding = "utf-8"
 					)
 
-					# TODO: progress bar (extra function?)
-					regexPattern = re.compile(REGEX_LOUDNORM)
-
-					jsonStrings = []
-					i = -1
-					processFinished = False
-
-					# Decode output of ffmpeg
-					for line in process.stdout:
-						print(line.strip())
-						regexMatch = regexPattern.match(line.strip())
-						if regexMatch:
-							i += 1
-							jsonStrings.append("")
-							processFinished = True
-						elif processFinished:
-							jsonStrings[i] += line
-
-					# Wait for process to finish
-					process.wait()
-
-					# Decode json output
-					processOutJson = []
-					for jsonString in jsonStrings:
-						processOutJson.append(json.loads(jsonString))
+					# Decode ffmpeg output
+					processOutJson = decodeFfmpegOutput(
+						process,
+						threadProgress[threading.get_ident()],
+						(amountAudioStreams[0] + amountAudioStreams[1]) * progressAudioEncode
+					)
 
 			command = [
 				ffmpeg,
@@ -478,8 +533,8 @@ def processEpisode(ep):
 				"0:s",
 				"-map_metadata:g",			# Map global metadata to output
 				"0:g",
-				# "-max_interleave_delta",	# Needed for use with subtitles, otherwise audio has buffering issues
-				# "0"						# TODO: check if this is still needed
+				"-max_interleave_delta",	# Needed for use with subtitles, otherwise audio has buffering issues
+				"0"
 			])
 
 			# Mark all original audio streams as english
@@ -497,9 +552,10 @@ def processEpisode(ep):
 				"language=eng",
 				"-metadata",			# Set title
 				"title=" + episodeFullTitle,
-				tempFilePath if enableNormalization else convertedVideoFilePath		# Output video
+				convertedVideoFilePath	# Output video
 			])
 
+			# Add additional audio track with offset, speed adjustment and normalize loudness of all audio tracks
 			process = subprocess.Popen(
 				command,
 				stdout = subprocess.PIPE,
@@ -508,151 +564,12 @@ def processEpisode(ep):
 				encoding = "utf-8"
 			)
 
-			# TODO: progress bar (extra function?)
-			regexPattern = re.compile(REGEX_LOUDNORM)
-
-			jsonStrings = []
-			i = -1
-			processFinished = False
-
-			# Decode output of ffmpeg
-			for line in process.stdout:
-				print(line.strip())
-				if enableNormalization:
-					regexMatch = regexPattern.match(line.strip())
-					if regexMatch:
-						i += 1
-						jsonStrings.append("")
-						processFinished = True
-					elif processFinished:
-						jsonStrings[i] += line
-
-			process.wait()
-
-			if enableNormalization:
-				processOutJson = []
-				for jsonString in jsonStrings:
-					processOutJson.append(json.loads(jsonString))
-
-				# for idxStream, outJson in enumerate(processOutJson):
-				# 	if outJson["normalization_type"] != "linear":
-				# 		if idxStream < amountAudioStreams[0]:
-				# 			errorCritical(
-				# 				"Unable to normalize audio stream "
-				# 				+ str(idxStream)
-				# 				+ " in file \"" + videoFilePath + "\"!"
-				# 			)
-				# 		else:
-				# 			errorCritical(
-				# 				"Unable to normalize audio stream "
-				# 				+ str(idxStream - amountAudioStreams[0])
-				# 				+ " in file \""
-				# 				+ audioFilePath + "\"!"
-				# 			)
-
-			# TODO: Check if normalization was successful (all audio streams were normalized linearly, not dynamically)
-			# TODO: Parse output
-			# TODO: Progress bar
-
-			raise Exception("DEBUG")
-
-			# command = [
-			# 	ffmpeg,
-			# 	"-hide_banner",			# Hide start info
-			# 	# "-loglevel",			# Less output
-			# 	# "error",
-			# 	"-y",  					# Override files
-			# 	"-i",  					# Input video
-			# 	videoFilePath,
-			# 	"-ss",  				# Skip specified time in next input file
-			# 	ep.audioStart,
-			# 	"-i",  					# Input audio
-			# 	audioFilePath,
-			# 	"-filter_complex",  	# Adjust speed and delay of additional audio track
-			# 	"[1:a]adelay=delays=" + ep.audioOffset + ":all=true,atempo=" + str(audioSpeed) + "[out]",
-			# 	"-c:v",  				# Copy video stream
-			# 	"copy"
-			# ]
-
-			# # Copy all original audio streams
-			# for i in range(amountAudioStreams[0]):
-			# 	command.append("-c:a:" + str(i))
-			# 	command.append("copy")
-			#
-			# # Re-encode all additional audio streams
-			# for i in range(amountAudioStreams[1]):
-			# 	command.append("-c:a:" + str(i + amountAudioStreams[0]))
-			# 	command.append(str(audioCodecs[amountAudioStreams[0] + i]))
-			# 	command.append("-b:a:" + str(i + amountAudioStreams[0]))
-			# 	command.append(str(audioBitRates[amountAudioStreams[0] + i]))
-
-			# command.extend([
-			# 	"-c:s",  				# Copy subtitles
-			# 	"copy",
-			# 	"-map",  				# Use everything from first input file
-			# 	"0",
-			# 	"-map",  				# Use filtered audio
-			# 	"[out]",
-			# 	"-max_interleave_delta",  # Needed for use with subtitles, otherwise audio has buffering issues
-			# 	"0"
-			# ])
-			#
-			# # Mark all original audio streams as english
-			# for i in range(amountAudioStreams[0]):
-			# 	command.append("-metadata:s:a:" + str(i))
-			# 	command.append("language=eng")
-			#
-			# # Mark all additional audio streams as german
-			# for i in range(amountAudioStreams[1]):
-			# 	command.append("-metadata:s:a:" + str(i + amountAudioStreams[0]))
-			# 	command.append("language=deu")
-			#
-			# command.extend([
-			# 	"-metadata:s:s:0",  	# Set subtitle stream language
-			# 	"language=eng",
-			# 	"-metadata",  			# Set title
-			# 	"title=" + episodeFullTitle,
-			# 	tempFilePath if enableNormalization else convertedVideoFilePath  # Output video
-			# ])
-
-			# Add additional audio track with offset and speed adjustment
-			process = subprocess.Popen(
-				command,
-				stdout = subprocess.PIPE,
-				stderr = subprocess.STDOUT,
-				universal_newlines = True,
-				encoding = "utf-8"
+			# Decode ffmpeg output
+			processOutJson = decodeFfmpegOutput(
+				process,
+				threadProgress[threading.get_ident()],
+				(amountAudioStreams[0] * int(enableNormalization) + amountAudioStreams[1]) * progressAudioEncode
 			)
-
-			captureTotalFrames = False
-			totalFrames = 0
-			percentCounter = 0
-			maxPercent = amountAudioStreams[1] * progressAudioEncode
-			regexPatternMediaStream = re.compile(REGEX_MEDIA_STREAM)
-			regexPatternTotalFrames = re.compile(REGEX_TOTAL_FRAMES)
-			regexPatternCurrentFrame = re.compile(REGEX_CURRENT_FRAME)
-
-			# Decode output from ffmpeg
-			for line in process.stdout:
-				# Check for video stream
-				regexMatch = regexPatternMediaStream.match(line.strip())
-				if regexMatch:
-					if regexMatch.group(1) == "0" and regexMatch.group(2) == "0":
-						captureTotalFrames = True
-
-				# Get total frames of video stream
-				if captureTotalFrames:
-					regexMatch = regexPatternTotalFrames.match(line.strip())
-					if regexMatch:
-						totalFrames = int(regexMatch.group(1))
-						captureTotalFrames = False
-
-				# Get last processed frame
-				regexMatch = regexPatternCurrentFrame.match(line.strip())
-				if regexMatch:
-					progress = int(((int(regexMatch.group(1)) * maxPercent) / totalFrames) * (progressAudioEncode / 100))
-					threadProgress[threading.get_ident()].update(progress - percentCounter)
-					percentCounter = progress
 
 			# Wait for process to finish
 			process.wait()
@@ -669,151 +586,71 @@ def processEpisode(ep):
 					+ "\"! Exiting..."
 				)
 
-			# Add any missing percent value to progress bar
-			threadProgress[threading.get_ident()].update(maxPercent - percentCounter)
-			threadProgress[threading.get_ident()].refresh()
-
+			if enableNormalization:
+				pass
+				# TODO: Check if normalization was successful (all audio streams were normalized linearly, not dynamically)
+				# for idxStream, outJson in enumerate(processOutJson):
+				# 	if outJson["normalization_type"] != "linear":
+				# 		if idxStream < amountAudioStreams[0]:
+				# 			errorCritical(
+				# 				"Unable to normalize audio stream "
+				# 				+ str(idxStream)
+				# 				+ " in file \"" + videoFilePath + "\"!"
+				# 			)
+				# 		else:
+				# 			errorCritical(
+				# 				"Unable to normalize audio stream "
+				# 				+ str(idxStream - amountAudioStreams[0])
+				# 				+ " in file \""
+				# 				+ audioFilePath + "\"!"
+				# 			)
 		else:
 			errorCritical('"' + audioFilePath + "\" does not exist!")
 	else:
 		errorCritical('"' + videoFilePath + "\" does not exist!")
 
-	if enableNormalization:
-		# Check if temporary output file exists
-		if os.path.exists(tempFilePath):
-			logWrite("Normalizing loudness of file \"" + tempFilePath + "\"...")
+	# Check if output file exists
+	if os.path.exists(convertedVideoFilePath):
+		logWrite("Updating metadata of file \"" + convertedVideoFilePath + "\"...")
 
-			# Normalize loudness
-			process = subprocess.Popen([
-				ffmpegNormalize,
-				"-q",						# Quiet
-				"-pr",						# Show progress bar
-				"-f",						# Overwrite files
-				"-t",						# Loudness target
-				str(loudnessTarget),
-				"-lrt",						# Loudness range
-				str(loudnessRange),
-				"-tp",						# Loudness true peak
-				str(loudnessTruePeak),
-				"-ar",						# Sample rate for output file
-				str(normalizedAudioSampleRate),
-				tempFilePath,				# Input file
-				"-c:a",						# Re-encode audio with aac
-				#audioCodec,
-				"aac"
-				"-o",						# Output file
-				convertedVideoFilePath
-			],
-				stdout = subprocess.PIPE,
-				stderr = subprocess.STDOUT,
-				universal_newlines = True,
-				encoding = "utf-8"
+		# Update track statistics
+		process = subprocess.Popen([
+			mkvpropedit,
+			convertedVideoFilePath,
+			"--add-track-statistics-tags"
+		],
+			stdout = subprocess.PIPE,
+			stderr = subprocess.STDOUT,
+			universal_newlines = True,
+			encoding = "utf-8"
+		)
+
+		percentCounter = 0
+		regexPatternMKVPropEdit = re.compile(REGEX_MKVPROPEDIT)
+
+		# Decode output from mkvpropedit
+		for line in process.stdout:
+			# Get percentage
+			regexMatch = regexPatternMKVPropEdit.match(line.strip())
+			if regexMatch:
+				progress = int(int(regexMatch.group(1)) * (progressMKVProperties / 100))
+				threadProgress[threading.get_ident()].update(progress - percentCounter)
+				percentCounter = progress
+
+		# Wait for process to finish
+		process.wait()
+
+		# Check exit code
+		if process.returncode:
+			errorCritical(
+				"Failed to update metadata of file \""
+				+ convertedVideoFilePath
+				+ "\"! Exiting..."
 			)
 
-			percentCounter = 0
-			maxPercent = (amountAudioStreams[0] + amountAudioStreams[1]) * progressAudioEncode * 2
-			maxPercentFirstPass = (amountAudioStreams[0] + amountAudioStreams[1]) * progressAudioEncode
-			regexPatternNormalization = re.compile(REGEX_NORMALIZATION)
-			regexPatternNormalizationSecond = re.compile(REGEX_NORMALIZATION_SECOND)
-
-			# Decode output from ffmpeg
-			for line in process.stdout:
-				# Get percentage of first pass
-				regexMatch = regexPatternNormalization.match(line.strip())
-				if regexMatch:
-					progress = int(int(regexMatch.group(3)) * (progressAudioEncode / 100) \
-							   + progressAudioEncode * (int(regexMatch.group(1)) - 1))
-					threadProgress[threading.get_ident()].update(progress - percentCounter)
-					percentCounter = progress
-				else:
-					# Get percentage of second pass
-					regexMatch = regexPatternNormalizationSecond.match(line.strip())
-					if regexMatch:
-						break
-
-			# Add any missing percent value to progress bar
-			threadProgress[threading.get_ident()].update(maxPercentFirstPass - percentCounter)
-			threadProgress[threading.get_ident()].refresh()
-			percentCounter = maxPercentFirstPass
-
-			# Decode output from ffmpeg
-			for line in process.stdout:
-				# Get percentage of second pass
-				regexMatch = regexPatternNormalizationSecond.match(line.strip())
-				if regexMatch:
-					progress = int((int(regexMatch.group(1)) * (progressAudioEncode / 100)) \
-							   * (amountAudioStreams[1] + amountAudioStreams[1]) \
-							   + maxPercentFirstPass)
-					threadProgress[threading.get_ident()].update(progress - percentCounter)
-					percentCounter = progress
-
-			# Wait for process to finish
-			process.wait()
-
-			# Check exit code
-			if process.returncode:
-				errorCritical(
-					"Failed to normalize loudness of file \""
-					+ tempFilePath
-					+ "\"! Exiting..."
-				)
-
-			# Add any missing percent value to progress bar
-			threadProgress[threading.get_ident()].update(maxPercent - percentCounter)
-			threadProgress[threading.get_ident()].refresh()
-
-			# Delete temporary output file
-			os.remove(tempFilePath)
-		else:
-			errorCritical('"' + videoFilePath + "\" does not exist!")
-
-	if enableMKVPropedit:
-		# Check if output file exists
-		if os.path.exists(convertedVideoFilePath):
-			logWrite("Updating metadata of file \"" + convertedVideoFilePath + "\"...")
-
-			# Set title in video file properties
-			process = subprocess.Popen([
-				mkvpropedit,
-				convertedVideoFilePath,
-				"-e",
-				"info",
-				"-s",
-				"title=" + episodeFullTitle,
-				"--add-track-statistics-tags"
-			],
-				stdout = subprocess.PIPE,
-				stderr = subprocess.STDOUT,
-				universal_newlines = True,
-				encoding = "utf-8"
-			)
-
-			percentCounter = 0
-			regexPatternMKVPropEdit = re.compile(REGEX_MKVPROPEDIT)
-
-			# Decode output from mkvpropedit
-			for line in process.stdout:
-				# Get percentage
-				regexMatch = regexPatternMKVPropEdit.match(line.strip())
-				if regexMatch:
-					progress = int(int(regexMatch.group(1)) * (progressMKVProperties / 100))
-					threadProgress[threading.get_ident()].update(progress - percentCounter)
-					percentCounter = progress
-
-			# Wait for process to finish
-			process.wait()
-
-			# Check exit code
-			if process.returncode:
-				errorCritical(
-					"Failed to update metadata of file \""
-					+ convertedVideoFilePath
-					+ "\"! Exiting..."
-				)
-
-			# Add any missing percent value to progress bar
-			threadProgress[threading.get_ident()].update(progressMKVProperties - percentCounter)
-			threadProgress[threading.get_ident()].refresh()
+		# Add any missing percent value to progress bar
+		threadProgress[threading.get_ident()].update(progressMKVProperties - percentCounter)
+		threadProgress[threading.get_ident()].refresh()
 
 	# Remove thread progress from dictionary since thread is finished now
 	threadProgress[threading.get_ident()].close()


### PR DESCRIPTION
Use ffmpegs filter chains to only encode each audio stream at most once. This prevents unnecessary generational losses.